### PR TITLE
Fix: make decimal point in amount non-locale aware

### DIFF
--- a/src/QrPayment.php
+++ b/src/QrPayment.php
@@ -133,7 +133,7 @@ class QrPayment
 
         $qr = "SPD*1.0*";
         $qr .= sprintf("ACC:%s*", $this->getIBAN());
-        $qr .= sprintf("AM:%.2f*", $this->amount);
+        $qr .= sprintf("AM:%.2F*", $this->amount);
         $qr .= sprintf("CC:%s*", strtoupper($this->currency));
 
         if ($this->repeat) {


### PR DESCRIPTION
If locale is set to format numbers with anything other than dot, qr code is unreadable.
For example comma as standard czech decimal point.